### PR TITLE
Fixed html multiple tag

### DIFF
--- a/visual-tool/index.html
+++ b/visual-tool/index.html
@@ -15,11 +15,11 @@
   <div id="flex-wrapper">
 
     <div id="selectWrapper" style="display:flex;flex-direction:column;">
-      <select id="tunebookSelect" multiple=11" style="width:300px;height:95px">
+      <select id="tunebookSelect" multiple style="width:300px;height:95px">
         <option value="nottingham">Nottingham Dataset</option>
         <option value="custom">Custom file at visual-tool/tunes.txt</option>
       </select>
-      <select id="tuneSelect" multiple="1" style="width:300px;height:235px;">
+      <select id="tuneSelect" multiple style="width:300px;height:235px;">
       </select>
       <button id="testForErrors" style="margin-right:15px;width:300px;">Test All and Show Render Errors</button>
     </div>


### PR DESCRIPTION
There was an error with the multiple tag in the html file. This prevented the code from building via:

`npm run-script build `

which previously resulted in:

> ERROR in   Error: html-webpack-plugin could not minify the generated output.
  In production mode the html minifcation is enabled by default.
  If you are not generating a valid html output please disable it manually.
  You can do so by adding the following setting to your HtmlWebpackPlugin config:
  |
  |    minify: false
  |
  See https://github.com/jantimon/html-webpack-plugin#options for details.
  For parser dedicated bugs please create an issue here:
  https://danielruf.github.io/html-minifier-terser/
  Parse Error: <select id="tunebookSelect" multiple=11" style="width:300px;height:95px">........

This is now fixed with this pull request and it builds.